### PR TITLE
Convert tables to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,6 @@ public class Main {
 ### Acknowledgment
 This library is a port to Java of the wonderful library [Turndown.js](https://github.com/domchristie/turndown). This library passes the same test suite as the original library to ensure same behavior.
 
+The support to convert tables to markdown is ported from the [turndown-plugin-gfm](https://github.com/mixmark-io/turndown-plugin-gfm) library. It uses also the same test as that library.
+
 This project is supported by Intellij open source license

--- a/src/main/java/io/github/furstenheim/CopyDown.java
+++ b/src/main/java/io/github/furstenheim/CopyDown.java
@@ -131,7 +131,14 @@ public class CopyDown {
             addRule("blankReplacement", new Rule((element) -> CopyNode.isBlank(element), (content, element) ->
                     CopyNode.isBlock(element) ? "\n\n" : ""));
             addRule("paragraph", new Rule("p", (content, element) -> {return "\n\n" + content + "\n\n";}));
-            addRule("br", new Rule("br", (content, element) -> {return options.br + "\n";}));
+            addRule("br", new Rule("br", (content, element) -> {
+                // If the br tag is in a table keep the br tag. Otherwise, the table will not work in markdown.
+                if (element.parentNode() != null && Arrays.asList("td", "th").contains(element.parentNode().nodeName().toLowerCase())) {
+                    return element.outerHtml();
+                } else {
+                    return options.br + "\n";
+                }
+            }));
             addRule("heading", new Rule(new String[]{"h1", "h2", "h3", "h4", "h5", "h6" }, (content, element) -> {
                 Integer hLevel = Integer.parseInt(element.nodeName().substring(1, 2));
                 if (options.headingStyle == HeadingStyle.SETEXT && hLevel < 3) {

--- a/src/test/resources/tests.json
+++ b/src/test/resources/tests.json
@@ -787,6 +787,12 @@
     "output": "| Column 1 | Column 2 | Column 3 | Column 4 |\n| :-- | :-: | --: | --- |\n|  | Row 1, Column 2 | Row 1, Column 3 | Row 1, Column 4 |\n| Row 2, Column 1 |  | Row 2, Column 3 | Row 2, Column 4 |\n| Row 3, Column 1 | Row 3, Column 2 |  | Row 3, Column 4 |\n| Row 4, Column 1 | Row 4, Column 2 | Row 4, Column 3 |  |\n|  |  |  | Row 5, Column 4 |"
   },
   {
+    "name": "table with <br>",
+    "options": null,
+    "input": "<table>\n      <thead>\n        <tr>\n          <th>Column<br> 1</th>\n          <th>Column 2</th>\n        </tr>\n      </thead>\n      <tbody>\n        <tr>\n          <td>Row 1, <br> Column 1</td>\n          <td>Row 1, Column 2</td>\n        </tr>\n        <tr>\n          <td>Row 2, Column 1</td>\n          <td>Row 2, Column 2</td>\n        </tr>\n      </tbody>\n    </table>",
+    "output": "| Column<br>1 | Column 2 |\n| --- | --- |\n| Row 1,<br>Column 1 | Row 1, Column 2 |\n| Row 2, Column 1 | Row 2, Column 2 |"
+  },
+  {
     "name": "th in first row",
     "options": null,
     "input": "<table>\n      <tr>\n        <th>Heading</th>\n      </tr>\n      <tr>\n        <td>Content</td>\n      </tr>\n    </table>",

--- a/src/test/resources/tests.json
+++ b/src/test/resources/tests.json
@@ -761,5 +761,53 @@
     },
     "input": "\n<pre><code>\nCode\n\n</code></pre>\n    ",
     "output": "```\n\nCode\n\n```"
+  },
+  {
+    "name": "basic table without thead or tbody",
+    "options": null,
+    "input": "<table>\n      <tr><td>Row 1 Cell 1</td><td>Row 1 Cell 2</td></tr>\n      <tr><td>Row 2 Cell 1</td><td>Row 2 Cell 2</td></tr>\n    </table>",
+    "output": "| Row 1 Cell 1 | Row 1 Cell 2 |\n| --- | --- |\n| Row 2 Cell 1 | Row 2 Cell 2 |"
+  },
+  {
+    "name": "basic table",
+    "options": null,
+    "input": "<table>\n      <thead>\n        <tr>\n          <th>Column 1</th>\n          <th>Column 2</th>\n        </tr>\n      </thead>\n      <tbody>\n        <tr>\n          <td>Row 1, Column 1</td>\n          <td>Row 1, Column 2</td>\n        </tr>\n        <tr>\n          <td>Row 2, Column 1</td>\n          <td>Row 2, Column 2</td>\n        </tr>\n      </tbody>\n    </table>",
+    "output": "| Column 1 | Column 2 |\n| --- | --- |\n| Row 1, Column 1 | Row 1, Column 2 |\n| Row 2, Column 1 | Row 2, Column 2 |"
+  },
+  {
+    "name": "cell alignment",
+    "options": null,
+    "input": "<table>\n      <thead>\n        <tr>\n          <th align=\"left\">Column 1</th>\n          <th align=\"center\">Column 2</th>\n          <th align=\"right\">Column 3</th>\n          <th align=\"foo\">Column 4</th>\n        </tr>\n      </thead>\n      <tbody>\n        <tr>\n          <td>Row 1, Column 1</td>\n          <td>Row 1, Column 2</td>\n          <td>Row 1, Column 3</td>\n          <td>Row 1, Column 4</td>\n        </tr>\n        <tr>\n          <td>Row 2, Column 1</td>\n          <td>Row 2, Column 2</td>\n          <td>Row 2, Column 3</td>\n          <td>Row 2, Column 4</td>\n        </tr>\n      </tbody>\n    </table>",
+    "output": "| Column 1 | Column 2 | Column 3 | Column 4 |\n| :-- | :-: | --: | --- |\n| Row 1, Column 1 | Row 1, Column 2 | Row 1, Column 3 | Row 1, Column 4 |\n| Row 2, Column 1 | Row 2, Column 2 | Row 2, Column 3 | Row 2, Column 4 |"
+  },
+  {
+    "name": "empty cells",
+    "options": null,
+    "input": "<table>\n      <thead>\n        <tr>\n          <th align=\"left\">Column 1</th>\n          <th align=\"center\">Column 2</th>\n          <th align=\"right\">Column 3</th>\n          <th align=\"foo\">Column 4</th>\n        </tr>\n      </thead>\n      <tbody>\n        <tr>\n          <td></td>\n          <td>Row 1, Column 2</td>\n          <td>Row 1, Column 3</td>\n          <td>Row 1, Column 4</td>\n        </tr>\n        <tr>\n          <td>Row 2, Column 1</td>\n          <td></td>\n          <td>Row 2, Column 3</td>\n          <td>Row 2, Column 4</td>\n        </tr>\n        <tr>\n          <td>Row 3, Column 1</td>\n          <td>Row 3, Column 2</td>\n          <td></td>\n          <td>Row 3, Column 4</td>\n        </tr>\n        <tr>\n          <td>Row 4, Column 1</td>\n          <td>Row 4, Column 2</td>\n          <td>Row 4, Column 3</td>\n          <td></td>\n        </tr>\n        <tr>\n          <td></td>\n          <td></td>\n          <td></td>\n          <td>Row 5, Column 4</td>\n        </tr>\n      </tbody>\n    </table>",
+    "output": "| Column 1 | Column 2 | Column 3 | Column 4 |\n| :-- | :-: | --: | --- |\n|  | Row 1, Column 2 | Row 1, Column 3 | Row 1, Column 4 |\n| Row 2, Column 1 |  | Row 2, Column 3 | Row 2, Column 4 |\n| Row 3, Column 1 | Row 3, Column 2 |  | Row 3, Column 4 |\n| Row 4, Column 1 | Row 4, Column 2 | Row 4, Column 3 |  |\n|  |  |  | Row 5, Column 4 |"
+  },
+  {
+    "name": "th in first row",
+    "options": null,
+    "input": "<table>\n      <tr>\n        <th>Heading</th>\n      </tr>\n      <tr>\n        <td>Content</td>\n      </tr>\n    </table>",
+    "output": "| Heading |\n| --- |\n| Content |"
+  },
+  {
+    "name": "th first row in tbody",
+    "options": null,
+    "input": "<table>\n      <tbody>\n        <tr>\n          <th>Heading</th>\n        </tr>\n        <tr>\n          <td>Content</td>\n        </tr>\n      </tbody>\n    </table>",
+    "output": "| Heading |\n| --- |\n| Content |"
+  },
+  {
+    "name": "table with two tbodies",
+    "options": null,
+    "input": "<table>\n      <tbody>\n        <tr>\n          <th>Heading</th>\n        </tr>\n        <tr>\n          <td>Content</td>\n        </tr>\n      </tbody>\n      <tbody>\n        <tr>\n          <th>Heading</th>\n        </tr>\n        <tr>\n          <td>Content</td>\n        </tr>\n      </tbody>\n    </table>",
+    "output": "| Heading |\n| --- |\n| Content |\n| Heading |\n| Content |"
+  },
+  {
+    "name": "heading cells in both thead and tbody",
+    "options": null,
+    "input": "<table>\n      <thead><tr><th>Heading</th></tr></thead>\n      <tbody><tr><th>Cell</th></tr></tbody>\n    </table>",
+    "output": "| Heading |\n| --- |\n| Cell |"
   }
 ]

--- a/src/test/resources/tests.json
+++ b/src/test/resources/tests.json
@@ -793,6 +793,12 @@
     "output": "| Column<br>1 | Column 2 |\n| --- | --- |\n| Row 1,<br>Column 1 | Row 1, Column 2 |\n| Row 2, Column 1 | Row 2, Column 2 |"
   },
   {
+    "name": "table with colspan",
+    "options": null,
+    "input": "<table>\n      <thead>\n        <tr>\n          <th colspan=\"2\">Column 1</th>\n        <th colspan=\"1\">Column 3</th>\n        </tr>\n      </thead>\n      <tbody>\n        <tr>\n          <td>Row 1, Column 1</td>\n          <td>Row 1, Column 2</td>\n        <td>Row 1, Column 3</td>\n        </tr>\n        <tr>\n          <td colspan=\"3\">Row 2, Column 1</td>\n        </tr>\n      </tbody>\n    </table>",
+    "output": "| Column 1 | | Column 3 |\n| --- | --- | --- |\n| Row 1, Column 1 | Row 1, Column 2 | Row 1, Column 3 |\n| Row 2, Column 1 | | |"
+  },
+  {
     "name": "th in first row",
     "options": null,
     "input": "<table>\n      <tr>\n        <th>Heading</th>\n      </tr>\n      <tr>\n        <td>Content</td>\n      </tr>\n    </table>",


### PR DESCRIPTION
With this merge request it possible to convert tables to markdown. As inspiration I used https://github.com/mixmark-io/turndown-plugin-gfm/blob/master/src/tables.js. 

This pull request will fix #5 

So this html:
```html
<table>
  <thead>
    <tr>
      <th align="left">Column 1</th>
      <th align="center">Column 2</th>
      <th align="right">Column 3</th>
      <th align="foo">Column 4</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Row 1, Column 1</td>
      <td>Row 1, Column 2</td>
      <td>Row 1, Column 3</td>
      <td>Row 1, Column 4</td>
    </tr>
    <tr>
      <td>Row 2, Column 1</td>
      <td>Row 2, Column 2</td>
      <td>Row 2, Column 3</td>
      <td>Row 2, Column 4</td>
    </tr>
  </tbody>
</table>
```

will be converted to:
```md
| Column 1 | Column 2 | Column 3 | Column 4 |
| :-- | :-: | --: | --- |
| Row 1, Column 1 | Row 1, Column 2 | Row 1, Column 3 | Row 1, Column 4 |
| Row 2, Column 1 | Row 2, Column 2 | Row 2, Column 3 | Row 2, Column 4 |
```

And in github this will showed as:
| Column 1 | Column 2 | Column 3 | Column 4 |
| :-- | :-: | --: | --- |
| Row 1, Column 1 | Row 1, Column 2 | Row 1, Column 3 | Row 1, Column 4 |
| Row 2, Column 1 | Row 2, Column 2 | Row 2, Column 3 | Row 2, Column 4 |

A nice thing of the java `org.jsoup:jsoup` library is that tables without a tbody or thead can also be converted, because jsoup add tbody if none is present. This isn't working/supported by the turndown-plugin-gfm library. 